### PR TITLE
feat: Support Manhattan distance for Chroma

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration
 
 ### Qdrant Options
 
-| Flag                      | Description                                                                                        |
-| ------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--qdrant.collection`     | Target collection name.                                                                            |
-| `--qdrant.url`            | Qdrant gRPC URL. Default: `"http://localhost:6334"`                                                |
-| `--qdrant.api-key`        | Qdrant API key. Optional.                                                                          |
-| `--qdrant.dense-vector`   | Name of the dense vector in Qdrant. Default: `"dense_vector"`                                      |
-| `--qdrant.id-field`       | Field storing Pinecone IDs in Qdrant. Default: `"__id__"`                                          |
-| `--qdrant.distance`       | Distance metric for the Qdrant collection. `"cosine"` or `"dot"` or `"euclid"`. Default: `"euclid"`|
-| `--qdrant.document-field` | Field storing Chroma documents in Qdrant. Default: `"document"`                                    |
+| Flag                      | Description                                                                                                      |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--qdrant.collection`     | Target collection name.                                                                                          |
+| `--qdrant.url`            | Qdrant gRPC URL. Default: `"http://localhost:6334"`                                                              |
+| `--qdrant.api-key`        | Qdrant API key. Optional.                                                                                        |
+| `--qdrant.dense-vector`   | Name of the dense vector in Qdrant. Default: `"dense_vector"`                                                    |
+| `--qdrant.id-field`       | Field storing Pinecone IDs in Qdrant. Default: `"__id__"`                                                        |
+| `--qdrant.distance`       | Distance metric for the Qdrant collection. `"cosine"`, `"dot"`, `"manhattan"` or `"euclid"`. Default: `"euclid"` |
+| `--qdrant.document-field` | Field storing Chroma documents in Qdrant. Default: `"document"`                                                  |
 
 * See [Shared Migration Options](#shared-migration-options) for common migration parameters.
 

--- a/cmd/migrate_from_chroma.go
+++ b/cmd/migrate_from_chroma.go
@@ -25,7 +25,7 @@ type MigrateFromChromaCmd struct {
 	Migration     commons.MigrationConfig `embed:"" prefix:"migration."`
 	IdField       string                  `prefix:"qdrant." help:"Field storing Chroma IDs in Qdrant." default:"__id__"`
 	DenseVector   string                  `prefix:"qdrant." help:"Name of the dense vector in Qdrant" default:"dense_vector"`
-	Distance      string                  `prefix:"qdrant." enum:"cosine,dot,euclid" help:"Distance metric for the Qdrant collection" default:"euclid"`
+	Distance      string                  `prefix:"qdrant." enum:"cosine,dot,euclid,manhattan" help:"Distance metric for the Qdrant collection" default:"euclid"`
 	DocumentField string                  `prefix:"qdrant." help:"Field storing Chroma documents in Qdrant." default:"document"`
 
 	targetHost string
@@ -175,9 +175,10 @@ func (r *MigrateFromChromaCmd) prepareTargetCollection(ctx context.Context, coll
 	}
 
 	distanceMapping := map[string]qdrant.Distance{
-		"euclid": qdrant.Distance_Euclid,
-		"cosine": qdrant.Distance_Cosine,
-		"dot":    qdrant.Distance_Dot,
+		"euclid":    qdrant.Distance_Euclid,
+		"cosine":    qdrant.Distance_Cosine,
+		"dot":       qdrant.Distance_Dot,
+		"manhattan": qdrant.Distance_Manhattan,
 	}
 
 	createReq := &qdrant.CreateCollection{


### PR DESCRIPTION
Allow users to specify Manhattan as the distance metric when auto-creating the Qdrant collection.