### PR TITLE
refactor: Don't poll source count after every batch

### DIFF
--- a/cmd/migrate_from_chroma.go
+++ b/cmd/migrate_from_chroma.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	chroma "github.com/amikos-tech/chroma-go/pkg/api/v2"
 	"github.com/pterm/pterm"
@@ -200,7 +199,6 @@ func (r *MigrateFromChromaCmd) prepareTargetCollection(ctx context.Context, coll
 }
 
 func (r *MigrateFromChromaCmd) migrateData(ctx context.Context, collection chroma.Collection, targetClient *qdrant.Client, sourcePointCount uint64) error {
-	startTime := time.Now()
 	batchSize := r.Migration.BatchSize
 
 	var currentOffset uint64 = 0
@@ -295,16 +293,6 @@ func (r *MigrateFromChromaCmd) migrateData(ctx context.Context, collection chrom
 		}
 
 		bar.Add(count)
-
-		// If one minute elapsed get updated sourcePointCount
-		// Useful if any new points were added to the source during migration
-		if time.Since(startTime) > time.Minute {
-			sourcePointCount, err = r.countChromaVectors(ctx, collection)
-			if err != nil {
-				return fmt.Errorf("failed to count vectors in Chroma: %w", err)
-			}
-			bar.Total = int(sourcePointCount)
-		}
 	}
 
 	pterm.Success.Printfln("Data migration finished successfully")

--- a/cmd/migrate_from_milvus.go
+++ b/cmd/migrate_from_milvus.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
-	"time"
 
 	"github.com/milvus-io/milvus/client/v2/column"
 	"github.com/milvus-io/milvus/client/v2/entity"
@@ -182,7 +181,6 @@ func (r *MigrateFromMilvusCmd) prepareTargetCollection(ctx context.Context, sour
 }
 
 func (r *MigrateFromMilvusCmd) migrateData(ctx context.Context, sourceClient *milvusclient.Client, targetClient *qdrant.Client, sourcePointCount uint64) error {
-	startTime := time.Now()
 	batchSize := r.Migration.BatchSize
 
 	var offsetID *qdrant.PointId
@@ -299,15 +297,6 @@ func (r *MigrateFromMilvusCmd) migrateData(ctx context.Context, sourceClient *mi
 			break
 		}
 
-		// If one minute elapsed get updated sourcePointCount.
-		// Useful if any new points were added to the source during migration.
-		if time.Since(startTime) > time.Minute {
-			sourcePointCount, err = r.countMilvusVectors(ctx, sourceClient)
-			if err != nil {
-				return fmt.Errorf("failed to count vectors in Milvus: %w", err)
-			}
-			bar.Total = int(sourcePointCount)
-		}
 	}
 
 	pterm.Success.Printfln("Data migration finished successfully")

--- a/cmd/migrate_from_pinecone.go
+++ b/cmd/migrate_from_pinecone.go
@@ -7,7 +7,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"github.com/pterm/pterm"
@@ -208,7 +207,6 @@ func (r *MigrateFromPineconeCmd) prepareTargetCollection(ctx context.Context, so
 }
 
 func (r *MigrateFromPineconeCmd) migrateData(ctx context.Context, sourceIndexConn *pinecone.IndexConnection, targetClient *qdrant.Client, sourcePointCount uint64) error {
-	startTime := time.Now()
 	batchSize := r.Migration.BatchSize
 
 	var offsetId *qdrant.PointId
@@ -312,15 +310,6 @@ func (r *MigrateFromPineconeCmd) migrateData(ctx context.Context, sourceIndexCon
 			break
 		}
 
-		// If one minute elapsed get updated sourcePointCount.
-		// Useful if any new points were added to the source during migration.
-		if time.Since(startTime) > time.Minute {
-			sourcePointCount, err = r.countPineconeVectors(ctx, sourceIndexConn)
-			if err != nil {
-				return fmt.Errorf("failed to count vectors in Pinecone: %w", err)
-			}
-			bar.Total = int(sourcePointCount)
-		}
 	}
 
 	pterm.Success.Printfln("Data migration finished successfully")

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/pterm/pterm"
 
@@ -213,7 +212,6 @@ func getFieldType(dataType qdrant.PayloadSchemaType) *qdrant.FieldType {
 }
 
 func (r *MigrateFromQdrantCmd) migrateData(ctx context.Context, sourceClient *qdrant.Client, sourceCollection string, targetClient *qdrant.Client, targetCollection string, sourcePointCount uint64) error {
-	startTime := time.Now()
 	limit := uint32(r.Migration.BatchSize)
 
 	var offsetId *qdrant.PointId
@@ -323,18 +321,6 @@ func (r *MigrateFromQdrantCmd) migrateData(ctx context.Context, sourceClient *qd
 			break
 		}
 
-		// If one minute elapsed get updated sourcePointCount.
-		// Useful if any new points were added to the source during migration.
-		if time.Since(startTime) > time.Minute {
-			sourcePointCount, err := sourceClient.Count(ctx, &qdrant.CountPoints{
-				CollectionName: sourceCollection,
-				Exact:          qdrant.PtrOf(true),
-			})
-			if err != nil {
-				return fmt.Errorf("failed to count points in source: %w", err)
-			}
-			bar.Total = int(sourcePointCount)
-		}
 	}
 
 	pterm.Success.Printfln("Data migration finished successfully")


### PR DESCRIPTION
Currently, the tool

- Checks for new entries in the source after each batch insert.
- Updates the progress bar's total count if new entries were found.
- This polling begins 1 minute after starting migration.

This is inefficient. A better solution might be to poll just once per minute instead of after every batch, but for now, this PR removes the polling.