### PR TITLE
test: Add Pinecone source integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Migrate data from a **Pinecone** database to **Qdrant**:
 
 ```bash
 migration pinecone \
-    --pinecone.host 'https://example-index-12345.svc.region.pinecone.io' \
+    --pinecone.index-host 'https://example-index.svc.region.pinecone.io' \
+    --pinecone.index-name 'example-index' \
     --pinecone.api-key 'optional-pinecone-api-key' \
     --qdrant.url 'https://example.cloud-region.cloud-provider.cloud.qdrant.io:6334' \
     --qdrant.api-key 'optional-qdrant-api-key' \
@@ -113,7 +114,7 @@ With Docker:
 
 ```bash
 docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration pinecone \
-    --pinecone.host 'https://example-index-12345.svc.region.pinecone.io' \
+    --pinecone.index-host 'https://example-index.svc.region.pinecone.io' \
     ...
 ```
 
@@ -121,9 +122,11 @@ docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration
 
 | Flag                            | Description                                                     |
 | ------------------------------- | --------------------------------------------------------------- |
-| `--pinecone.api-key`            | Pinecone API key for authentication                             |
-| `--pinecone.host`               | Pinecone index host URL (e.g., `https://your-pinecone-url`)     |
-| `--pinecone.namespace`          | Namespace of the partition to migrate                           |
+| `--pinecone.index-name`              | Pinecone index name.                                       |
+| `--pinecone.index-host`         | Pinecone index host URL (e.g., `https://your-pinecone-url`)     |
+| `--pinecone.api-key`            | Pinecone API key for authentication.                            |
+| `--pinecone.namespace`          | Namespace of the partition to migrate. Optional.                |
+| `--pinecone.service-host`       | Pinecone service host URL. Optional.                            |
 
 #### Qdrant Options
 

--- a/cmd_test/constants_test.go
+++ b/cmd_test/constants_test.go
@@ -1,0 +1,14 @@
+package cmd_test
+
+const (
+	testCollectionName    = "test-collection"
+	qdrantPort            = "6334"
+	qdrantAPIKey          = "00000000"
+	idField               = "__id__"
+	denseVectorName       = "dense_vector"
+	sparseVectorName      = "sparse_vector"
+	batchSize             = 10
+	offsetsCollectionName = "_migration_marker"
+	totalEntries          = 100
+	dimension             = 384
+)

--- a/cmd_test/image_test.go
+++ b/cmd_test/image_test.go
@@ -46,3 +46,24 @@ func chromaContainer(ctx context.Context, t *testing.T) testcontainers.Container
 
 	return container
 }
+
+func pineconeContainer(ctx context.Context, t *testing.T) testcontainers.Container {
+
+	req := testcontainers.ContainerRequest{
+		Image:        "ghcr.io/pinecone-io/pinecone-local:latest",
+		ExposedPorts: []string{"5081/tcp", "5082/tcp"},
+		Env: map[string]string{
+			"PORT": "5081",
+		},
+		WaitingFor: wait.ForAll(wait.ForListeningPort("5081/tcp").WithStartupTimeout(30*time.Second),
+			wait.ForListeningPort("5082/tcp").WithStartupTimeout(30*time.Second)),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+
+	return container
+}

--- a/cmd_test/migrate_from_chroma_test.go
+++ b/cmd_test/migrate_from_chroma_test.go
@@ -17,19 +17,10 @@ import (
 )
 
 const (
-	testCollectionName    = "test_collection"
-	chromaPort            = "8000"
-	qdrantPort            = "6334"
-	qdrantAPIKey          = "00000000"
-	idField               = "__id__"
-	documentField         = "document"
-	sourceField           = "source"
-	denseVectorField      = "dense_vector"
-	distance              = "euclid"
-	batchSize             = 10
-	offsetsCollectionName = "_migration_marker"
-	totalEntries          = 100
-	dimension             = 384
+	chromaPort    = "8000"
+	sourceField   = "source"
+	documentField = "document"
+	distance      = "euclid"
 )
 
 func TestMigrateFromChroma(t *testing.T) {
@@ -123,7 +114,7 @@ func TestMigrateFromChroma(t *testing.T) {
 		IdField:       idField,
 		DocumentField: documentField,
 		Distance:      distance,
-		DenseVector:   denseVectorField,
+		DenseVector:   denseVectorName,
 	}
 
 	err = migrationCmd.Run(&cmd.Globals{})
@@ -165,7 +156,7 @@ func TestMigrateFromChroma(t *testing.T) {
 		require.Equal(t, expected.document, point.Payload[documentField].GetStringValue())
 		require.Equal(t, expected.source, point.Payload[sourceField].GetStringValue())
 
-		vector := point.Vectors.GetVectors().GetVectors()[denseVectorField].GetData()
+		vector := point.Vectors.GetVectors().GetVectors()[denseVectorName].GetData()
 		require.Equal(t, expected.vector, vector)
 	}
 }

--- a/cmd_test/migrate_from_pinecone_test.go
+++ b/cmd_test/migrate_from_pinecone_test.go
@@ -1,0 +1,170 @@
+package cmd_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/qdrant/go-client/qdrant"
+
+	"github.com/qdrant/migration/cmd"
+	"github.com/qdrant/migration/pkg/commons"
+)
+
+func TestMigrateFromPinecone(t *testing.T) {
+	ctx := context.Background()
+
+	qdrantContainer := qdrantContainer(ctx, t, qdrantAPIKey)
+	defer func() {
+		if err := qdrantContainer.Terminate(ctx); err != nil {
+			t.Errorf("Failed to terminate Qdrant container: %v", err)
+		}
+	}()
+
+	pineconeContainer := pineconeContainer(ctx, t)
+	defer func() {
+		if err := pineconeContainer.Terminate(ctx); err != nil {
+			t.Errorf("Failed to terminate Pinecone container: %v", err)
+		}
+	}()
+
+	pineconeHost, err := pineconeContainer.PortEndpoint(context.Background(), "5081/tcp", "http")
+	require.NoError(t, err)
+	pineconeIndexHost, err := pineconeContainer.PortEndpoint(context.Background(), "5082/tcp", "http")
+	require.NoError(t, err)
+
+	qdrantHost, err := qdrantContainer.Host(ctx)
+	require.NoError(t, err)
+	qdrantPort, err := qdrantContainer.MappedPort(ctx, qdrantPort)
+	require.NoError(t, err)
+
+	pineconeClient, err := pinecone.NewClient(pinecone.NewClientParams{
+		Host:   pineconeHost,
+		ApiKey: "qdrant-migration-test",
+	})
+	require.NoError(t, err)
+
+	metric := pinecone.Euclidean
+	dims := int32(dimension)
+
+	indexName := "my-serverless-index"
+
+	_, err = pineconeClient.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
+		Name:      indexName,
+		Dimension: &dims,
+		Metric:    &metric,
+		Cloud:     pinecone.Aws,
+		Region:    "us-east-1",
+	})
+	require.NoError(t, err)
+
+	indexConn, err := pineconeClient.Index(pinecone.NewIndexConnParams{
+		Host: pineconeIndexHost,
+	})
+	require.NoError(t, err)
+
+	testIDs := make([]string, totalEntries)
+	testVectors := make([][]float32, totalEntries)
+	testMetadatas := make([]map[string]interface{}, totalEntries)
+
+	for i := 0; i < totalEntries; i++ {
+		testIDs[i] = fmt.Sprintf("%d", i+1)
+
+		randomVector := make([]float32, dimension)
+		for j := range randomVector {
+			randomVector[j] = rand.Float32()
+		}
+		testVectors[i] = randomVector
+
+		testMetadatas[i] = map[string]interface{}{
+			"source": fmt.Sprintf("test%d", i+1),
+		}
+	}
+
+	vectors := make([]*pinecone.Vector, totalEntries)
+	for i := range testIDs {
+		metadata, err := structpb.NewStruct(testMetadatas[i])
+		require.NoError(t, err)
+		vectors[i] = &pinecone.Vector{
+			Id:       testIDs[i],
+			Values:   &testVectors[i],
+			Metadata: metadata,
+		}
+	}
+
+	_, err = indexConn.UpsertVectors(ctx, vectors)
+	require.NoError(t, err)
+
+	qdrantClient, err := qdrant.NewClient(&qdrant.Config{
+		Host:   qdrantHost,
+		Port:   qdrantPort.Int(),
+		APIKey: qdrantAPIKey,
+	})
+	require.NoError(t, err)
+	defer qdrantClient.Close()
+
+	migrationCmd := &cmd.MigrateFromPineconeCmd{
+		Pinecone: commons.PineconeConfig{
+			IndexName:   indexName,
+			IndexHost:   pineconeIndexHost,
+			ServiceHost: pineconeHost,
+			APIKey:      "qdrant-migration-test",
+		},
+		Qdrant: commons.QdrantConfig{
+			Url:        "http://" + qdrantHost + ":" + qdrantPort.Port(),
+			Collection: testCollectionName,
+			APIKey:     qdrantAPIKey,
+		},
+		Migration: commons.MigrationConfig{
+			BatchSize:            batchSize,
+			CreateCollection:     true,
+			EnsurePayloadIndexes: true,
+			OffsetsCollection:    offsetsCollectionName,
+		},
+		IdField:      idField,
+		DenseVector:  denseVectorName,
+		SparseVector: sparseVectorName,
+	}
+
+	err = migrationCmd.Run(&cmd.Globals{})
+	require.NoError(t, err)
+
+	points, err := qdrantClient.Scroll(ctx, &qdrant.ScrollPoints{
+		CollectionName: testCollectionName,
+		Limit:          qdrant.PtrOf(uint32(len(testIDs))),
+		WithPayload:    qdrant.NewWithPayload(true),
+		WithVectors:    qdrant.NewWithVectors(true),
+	})
+	require.NoError(t, err)
+	require.Len(t, points, len(testIDs))
+
+	expectedPoints := make(map[string]struct {
+		source string
+		vector []float32
+	})
+	for i, id := range testIDs {
+		expectedPoints[id] = struct {
+			source string
+			vector []float32
+		}{
+			source: testMetadatas[i]["source"].(string),
+			vector: testVectors[i],
+		}
+	}
+
+	for _, point := range points {
+		id := point.Payload[idField].GetStringValue()
+		expected, exists := expectedPoints[id]
+		require.True(t, exists)
+
+		require.Equal(t, expected.source, point.Payload["source"].GetStringValue())
+
+		vector := point.Vectors.GetVectors().GetVectors()[denseVectorName].GetData()
+		require.Equal(t, expected.vector, vector)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pterm/pterm v0.12.80
 	github.com/qdrant/go-client v1.14.0
 	github.com/stretchr/testify v1.10.0
-	github.com/testcontainers/testcontainers-go v0.36.0
+	github.com/testcontainers/testcontainers-go v0.37.0
 	google.golang.org/grpc v1.72.1
 )
 
@@ -73,7 +73,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
-	github.com/magiconair/properties v1.8.9 // indirect
+	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/milvus-io/milvus-proto/go-api/v2 v2.5.11 // indirect
 	github.com/milvus-io/milvus/pkg/v2 v2.5.11 // indirect
@@ -111,6 +111,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/testcontainers/testcontainers-go/modules/pinecone v0.37.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 h1:PpXWgLPs+Fqr32
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.9 h1:nWcCbLq1N2v/cpNsy5WvQ37Fb+YElfq20WJ/a8RkpQM=
 github.com/magiconair/properties v1.8.9/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
+github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -333,8 +335,12 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/testcontainers/testcontainers-go v0.36.0 h1:YpffyLuHtdp5EUsI5mT4sRw8GZhO/5ozyDT1xWGXt00=
 github.com/testcontainers/testcontainers-go v0.36.0/go.mod h1:yk73GVJ0KUZIHUtFna6MO7QS144qYpoY8lEEtU9Hed0=
+github.com/testcontainers/testcontainers-go v0.37.0 h1:L2Qc0vkTw2EHWQ08djon0D2uw7Z/PtHS/QzZZ5Ra/hg=
+github.com/testcontainers/testcontainers-go v0.37.0/go.mod h1:QPzbxZhQ6Bclip9igjLFj6z0hs01bU8lrl2dHQmgFGM=
 github.com/testcontainers/testcontainers-go/modules/chroma v0.36.0 h1:aP1Xifh3Igcr3diGj/rP4MGasyjdb26hvkN/KCDPLyg=
 github.com/testcontainers/testcontainers-go/modules/chroma v0.36.0/go.mod h1:4VyK3KXTZ6ATn08mKfW6BdCTknMzj9wTd6ANFCkZ1N4=
+github.com/testcontainers/testcontainers-go/modules/pinecone v0.37.0 h1:Pfj7ahPeT7Hd3REIJ0pOaBXxSygUSFcncmquSx0p4Fo=
+github.com/testcontainers/testcontainers-go/modules/pinecone v0.37.0/go.mod h1:YRkKSMNvSTzyv2ePa2vf0V5WCzU6e4/zR3Td6zejwEE=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/pkg/commons/config.go
+++ b/pkg/commons/config.go
@@ -27,9 +27,11 @@ type MilvusConfig struct {
 }
 
 type PineconeConfig struct {
-	APIKey    string `required:"true"  help:"Pinecone API key for authentication"`
-	Host      string `required:"true"  help:"Pinecone index host URL (e.g., https://example-index-12345.svc.region.pinecone.io)"`
-	Namespace string `help:"Namespace of the partition to migrate"`
+	IndexName   string `required:"true"  help:"Pinecone index name"`
+	IndexHost   string `required:"true"  help:"Pinecone index host URL (e.g., https://example-index-12345.svc.region.pinecone.io)"`
+	APIKey      string `required:"true"  help:"Pinecone API key for authentication"`
+	Namespace   string `help:"Namespace of the partition to migrate"`
+	ServiceHost string `help:"Pinecone service host URL. Optional."`
 }
 
 type ChromaConfig struct {


### PR DESCRIPTION
Follow up on #45.

This PR adds integration tests for the Pinecone source.
Uses https://docs.pinecone.io/guides/operations/local-development#database-emulator.