### PR TITLE
chore: Move --ensure-payload-indexes from common migration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,11 +356,12 @@ NOTE: If the target collection already exists, its vector size and dimensions mu
 
 #### Target Qdrant Options
 
-| Flag                  | Description                                                |
-| --------------------- | ---------------------------------------------------------- |
-| `--target.collection` | Target collection name                                     |
-| `--target.url`        | Target gRPC URL. Default: `"http://localhost:6334"`        |
-| `--target.api-key`    | API key for target instance                                |
+| Flag                              | Description                                         |
+| --------------------------------- | --------------------------------------------------- |
+| `--target.collection`             | Target collection name                              |
+| `--target.url`                    | Target gRPC URL. Default: `"http://localhost:6334"` |
+| `--target.api-key`                | API key for target instance                         |
+| `--target.ensure-payload-indexes` | Ensure payload indexes exist. Default: true         |
 
 See [Shared Migration Options](#shared-migration-options) for shared parameters.
 
@@ -375,5 +376,4 @@ These options apply to all migrations, regardless of the source.
 | `--migration.batch-size`             | Migration batch size. Default: 50                                    |
 | `--migration.restart`                | Restart migration without resuming from offset. Default: false       |
 | `--migration.create-collection`      | Create the collection if it doesn't exist. Default: true             |
-| `--migration.ensure-payload-indexes` | Ensure payload indexes exist. Default: true                          |
-| `--migration.offsets-collection`     | Collection to store migration offset. Default: `"_migration_offsets"` |
+| `--migration.offsets-collection`     | Collection to store migration offset. Default: `"_migration_offsets"`|

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -15,9 +15,10 @@ import (
 )
 
 type MigrateFromQdrantCmd struct {
-	Source    commons.QdrantConfig    `embed:"" prefix:"source."`
-	Target    commons.QdrantConfig    `embed:"" prefix:"target."`
-	Migration commons.MigrationConfig `embed:"" prefix:"migration."`
+	Source               commons.QdrantConfig    `embed:"" prefix:"source."`
+	Target               commons.QdrantConfig    `embed:"" prefix:"target."`
+	Migration            commons.MigrationConfig `embed:"" prefix:"migration."`
+	EnsurePayloadIndexes bool                    `help:"Ensure payload indexes are created" default:"true" prefix:"target."`
 
 	sourceHost string
 	sourcePort int
@@ -158,7 +159,7 @@ func (r *MigrateFromQdrantCmd) perpareTargetCollection(ctx context.Context, sour
 		return fmt.Errorf("failed to get target collection information: %w", err)
 	}
 
-	if r.Migration.EnsurePayloadIndexes {
+	if r.EnsurePayloadIndexes {
 		for name, schemaInfo := range sourceCollectionInfo.GetPayloadSchema() {
 			fieldType := getFieldType(schemaInfo.GetDataType())
 			if fieldType == nil {

--- a/pkg/commons/config.go
+++ b/pkg/commons/config.go
@@ -7,11 +7,10 @@ type QdrantConfig struct {
 }
 
 type MigrationConfig struct {
-	BatchSize            int    `short:"b" help:"Batch size" default:"50"`
-	Restart              bool   `help:"Restart the migration and do not continue from last offset" default:"false"`
-	CreateCollection     bool   `short:"c" help:"Create the collection if it does not exist" default:"true"`
-	EnsurePayloadIndexes bool   `help:"Ensure payload indexes are created" default:"true"`
-	OffsetsCollection    string `help:"Collection to store the current migration offset" default:"_migration_offsets"`
+	BatchSize         int    `short:"b" help:"Batch size" default:"50"`
+	Restart           bool   `help:"Restart the migration and do not continue from last offset" default:"false"`
+	CreateCollection  bool   `short:"c" help:"Create the collection if it does not exist" default:"true"`
+	OffsetsCollection string `help:"Collection to store the current migration offset" default:"_migration_offsets"`
 }
 
 type MilvusConfig struct {


### PR DESCRIPTION
`ensure-payload-indexes` is only applicable when migrating from Qdrant to Qdrant.

So move it from the common migration options to the target Qdrant options.

