### PR TITLE
Build multi-platform image using Suse BCI image

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -61,21 +61,23 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
+          # ttl.sh is an anonymous & ephemeral Docker image registry,
+          # check https://ttl.sh for more infos
           images: |
-            registry.cloud.qdrant.io/library/qdrant-migration
+            ttl.sh/qdrant-migration-${{ steps.extract_build_info.outputs.commit_short }}
           tags: |
-            type=raw,value=dev
+            type=raw,value=1h
 
-      - name: Build and push container image
+      - name: Build and push container images
         uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: .
-          push: false
-          load: true
-          sbom: false
+          push: true
+          load: false
+          sbom: true
           provenance: false
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
@@ -85,7 +87,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: registry.cloud.qdrant.io/library/qdrant-migration:dev
+          image-ref: ttl.sh/qdrant-migration-${{ steps.extract_build_info.outputs.commit_short }}:1h
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -98,4 +100,4 @@ jobs:
           bats-version: 1.11.1
 
       - name: Integration tests
-        run: make test_integration
+        run: make test_integration DEV_IMAGE_REF=ttl.sh/qdrant-migration-${{ steps.extract_build_info.outputs.commit_short }}:1h

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,18 @@
 # syntax=docker/dockerfile:1
 ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
 ARG BUILDKIT_SBOM_SCAN_STAGE=builder
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24 AS builder
+FROM registry.suse.com/bci/golang:1.24 AS builder
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
 ARG VERSION
 ARG BUILD
-
-RUN apt-get update && case "${TARGETARCH}" in \
-    amd64) apt-get install -y gcc-x86-64-linux-gnu ;; \
-    arm64) apt-get install -y gcc-aarch64-linux-gnu ;; \
-esac && rm -rf /var/lib/apt/lists/*
 
 COPY . /app
 
 WORKDIR /app
 
-RUN case "${TARGETARCH}" in \
-      amd64) CC=x86_64-linux-gnu-gcc ;; \
-      arm64) CC=aarch64-linux-gnu-gcc ;; \
-    esac && \
-    CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=$CC \
-    go build -ldflags "-X 'main.projectVersion=${VERSION:-0.0.0}' -X 'main.projectBuild=${BUILD:-dev}'" -o bin/qdrant-migration main.go
+RUN CGO_ENABLED=1 go build -ldflags "-X 'main.projectVersion=${VERSION:-0.0.0}' -X 'main.projectBuild=${BUILD:-dev}'" -o bin/qdrant-migration main.go
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.suse.com/bci/bci-minimal:15.6
+FROM registry.suse.com/bci/bci-minimal:15.6
 
 COPY --from=builder /app/bin/qdrant-migration /opt/
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PLATFORMS=darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
 VERSION=0.0.0
 BUILD=dev
+DEV_IMAGE_REF ?= registry.cloud.qdrant.io/library/qdrant-migration:dev
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
@@ -38,7 +39,7 @@ test: fmt vet lint test_integration
 
 .PHONY: test_integration
 test_integration:
-	bats --print-output-on-failure integration_tests
+	IMAGE_REF=$(DEV_IMAGE_REF) bats --print-output-on-failure integration_tests
 
 .PHONY: test_unit
 test_unit:

--- a/integration_tests/milvus_to_qdrant.bats
+++ b/integration_tests/milvus_to_qdrant.bats
@@ -1,3 +1,5 @@
+IMAGE_REF=${IMAGE_REF-registry.cloud.qdrant.io/library/qdrant-migration:dev}
+
 setup() {
   docker compose -f integration_tests/compose_files/milvus_to_qdrant.yaml up -d --wait
 }
@@ -48,7 +50,7 @@ teardown() {
   echo "Wait for a few seconds to load the vectors"
   sleep 5
 
-  run docker run --net=host --rm registry.cloud.qdrant.io/library/qdrant-migration:dev milvus \
+  run docker run --net=host --rm $IMAGE_REF milvus \
     --milvus.url 'http://localhost:19530' \
     --milvus.collection 'migrate_collection' \
     --qdrant.url 'http://localhost:6334' \

--- a/integration_tests/qdrant_to_qdrant.bats
+++ b/integration_tests/qdrant_to_qdrant.bats
@@ -1,3 +1,5 @@
+IMAGE_REF=${IMAGE_REF-registry.cloud.qdrant.io/library/qdrant-migration:dev}
+
 @test "Migrate Qdrant to Qdrant" {
   run curl -X PUT http://localhost:7333/collections/source_collection \
     -H 'Content-Type: application/json' \
@@ -47,7 +49,7 @@
 
   echo $source_result
 
-  run docker run --net=host --rm registry.cloud.qdrant.io/library/qdrant-migration:dev qdrant --source.url http://localhost:7334 --source.collection source_collection --target.url http://localhost:8334 --target.collection target_collection --migration.batch-size 1
+  run docker run --net=host --rm $IMAGE_REF qdrant --source.url http://localhost:7334 --source.collection source_collection --target.url http://localhost:8334 --target.collection target_collection --migration.batch-size 1
   [ $status -eq 0 ]
 
   run curl -s -X POST http://localhost:8333/collections/target_collection/points/scroll \
@@ -74,13 +76,13 @@
   [ $status -eq 0 ]
 
 
-  run docker run --net=host --rm registry.cloud.qdrant.io/library/qdrant-migration:dev qdrant --source.url http://localhost:7334 --source.collection source_collection --target.url http://localhost:7334 --target.collection source_collection --migration.batch-size 1
+  run docker run --net=host --rm $IMAGE_REF qdrant --source.url http://localhost:7334 --source.collection source_collection --target.url http://localhost:7334 --target.collection source_collection --migration.batch-size 1
   [ $status -ne 0 ]
   [[ "$output" =~ "source and target collections must be different" ]]
 }
 
 @test "Migrating with invalid port should fail" {
-  run docker run --net=host --rm registry.cloud.qdrant.io/library/qdrant-migration:dev qdrant --source.url http://localhost:invalid --source.collection source_collection --target.url http://localhost:8334 --target.collection source_collection --migration.batch-size 1
+  run docker run --net=host --rm $IMAGE_REF qdrant --source.url http://localhost:invalid --source.collection source_collection --target.url http://localhost:8334 --target.collection source_collection --migration.batch-size 1
   [ $status -ne 0 ]
   [[ "$output" =~ "invalid port \":invalid\" after host" ]]
 }


### PR DESCRIPTION
* Instead of trying to build the binary for the target platform using the image for build platform arch,
build the binary directly using the image with the right arch.
* For image scanning build the multi-arch image, push it to an anonymous & ephemeral Docker image registry
* Enable BATS test to use the built image for testing