### PR TITLE
chore: Customizable max gRPC message size

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ NOTE: If the target collection already exists, its vector size and dimensions mu
 | `--source.collection` | Source collection name                                     |
 | `--source.url`        | Source gRPC URL. Default: `"http://localhost:6334"`        |
 | `--source.api-key`    | API key for source instance                                |
+| `--source.max-message-size`  | Maximum gRPC message size in bytes (default: `33554432` = 32MB). Increase if you encounter `ResourceExhausted` errors with large batches.|
 
 #### Target Qdrant Options
 

--- a/cmd/migrate_from_chroma.go
+++ b/cmd/migrate_from_chroma.go
@@ -64,7 +64,7 @@ func (r *MigrateFromChromaCmd) Run(globals *Globals) error {
 	defer sourceCollection.Close()
 	defer sourceClient.Close()
 
-	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS)
+	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS, 0)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Qdrant target: %w", err)
 	}

--- a/cmd/migrate_from_milvus.go
+++ b/cmd/migrate_from_milvus.go
@@ -60,7 +60,7 @@ func (r *MigrateFromMilvusCmd) Run(globals *Globals) error {
 		return fmt.Errorf("failed to connect to Milvus source: %w", err)
 	}
 
-	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS)
+	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS, 0)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Qdrant target: %w", err)
 	}

--- a/cmd/migrate_from_pinecone.go
+++ b/cmd/migrate_from_pinecone.go
@@ -58,7 +58,7 @@ func (r *MigrateFromPineconeCmd) Run(globals *Globals) error {
 		return fmt.Errorf("failed to connect to Pinecone source: %w", err)
 	}
 
-	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS)
+	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS, 0)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Qdrant target: %w", err)
 	}

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -18,6 +18,7 @@ type MigrateFromQdrantCmd struct {
 	Source               commons.QdrantConfig    `embed:"" prefix:"source."`
 	Target               commons.QdrantConfig    `embed:"" prefix:"target."`
 	Migration            commons.MigrationConfig `embed:"" prefix:"migration."`
+	MaxMessageSize       int                     `help:"Maximum gRPC message size in bytes (default: 33554432 = 32MB)" default:"33554432" prefix:"source."`
 	EnsurePayloadIndexes bool                    `help:"Ensure payload indexes are created" default:"true" prefix:"target."`
 
 	sourceHost string
@@ -70,11 +71,11 @@ func (r *MigrateFromQdrantCmd) Run(globals *Globals) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	sourceClient, err := connectToQdrant(globals, r.sourceHost, r.sourcePort, r.Source.APIKey, r.sourceTLS)
+	sourceClient, err := connectToQdrant(globals, r.sourceHost, r.sourcePort, r.Source.APIKey, r.sourceTLS, r.MaxMessageSize)
 	if err != nil {
 		return fmt.Errorf("failed to connect to source: %w", err)
 	}
-	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Target.APIKey, r.targetTLS)
+	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Target.APIKey, r.targetTLS, 0)
 	if err != nil {
 		return fmt.Errorf("failed to connect to target: %w", err)
 	}

--- a/cmd/migrate_from_redis.go
+++ b/cmd/migrate_from_redis.go
@@ -66,7 +66,7 @@ func (r *MigrateFromRedisCmd) Run(globals *Globals) error {
 	})
 	defer rdb.Close()
 
-	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS)
+	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS, 0)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Qdrant target: %w", err)
 	}

--- a/cmd/migrate_from_weaviate.go
+++ b/cmd/migrate_from_weaviate.go
@@ -59,7 +59,7 @@ func (r *MigrateFromWeaviateCmd) Run(globals *Globals) error {
 		return fmt.Errorf("failed to connect to Weaviate source: %w", err)
 	}
 
-	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS)
+	targetClient, err := connectToQdrant(globals, r.targetHost, r.targetPort, r.Qdrant.APIKey, r.targetTLS, 0)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Qdrant target: %w", err)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -17,7 +17,7 @@ import (
 
 const HTTPS = "https"
 
-func connectToQdrant(globals *Globals, host string, port int, apiKey string, useTLS bool) (*qdrant.Client, error) {
+func connectToQdrant(globals *Globals, host string, port int, apiKey string, useTLS bool, maxMessageSize int) (*qdrant.Client, error) {
 	debugLogger := logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
 		pterm.Debug.Printf(msg, fields...)
 	})
@@ -35,6 +35,12 @@ func connectToQdrant(globals *Globals, host string, port int, apiKey string, use
 		loggingOptions := logging.WithLogOnEvents(logging.StartCall, logging.FinishCall)
 		grpcOptions = append(grpcOptions, grpc.WithChainUnaryInterceptor(logging.UnaryClientInterceptor(debugLogger, loggingOptions)))
 		grpcOptions = append(grpcOptions, grpc.WithChainStreamInterceptor(logging.StreamClientInterceptor(debugLogger, loggingOptions)))
+	}
+
+	if maxMessageSize != 0 {
+		grpcOptions = append(grpcOptions, grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMessageSize),
+		))
 	}
 
 	tlsConfig := tls.Config{

--- a/pkg/commons/config.go
+++ b/pkg/commons/config.go
@@ -11,7 +11,6 @@ type MigrationConfig struct {
 	Restart           bool   `help:"Restart the migration and do not continue from last offset" default:"false"`
 	CreateCollection  bool   `short:"c" help:"Create the collection if it does not exist" default:"true"`
 	OffsetsCollection string `help:"Collection to store the current migration offset" default:"_migration_offsets"`
-	MaxMessageSize    int    `help:"Maximum Qdrant gRPC message size in bytes (default: 33554432 = 32MB)" default:"33554432"`
 }
 
 type MilvusConfig struct {

--- a/pkg/commons/config.go
+++ b/pkg/commons/config.go
@@ -11,6 +11,7 @@ type MigrationConfig struct {
 	Restart           bool   `help:"Restart the migration and do not continue from last offset" default:"false"`
 	CreateCollection  bool   `short:"c" help:"Create the collection if it does not exist" default:"true"`
 	OffsetsCollection string `help:"Collection to store the current migration offset" default:"_migration_offsets"`
+	MaxMessageSize    int    `help:"Maximum Qdrant gRPC message size in bytes (default: 33554432 = 32MB)" default:"33554432"`
 }
 
 type MilvusConfig struct {


### PR DESCRIPTION
## Description

Fixes an issue when migrating from Qdrant to Qdrant with large batch sizes, which could trigger the following error:

```console
ERROR   failed to migrate data: failed to scroll date from source: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6895405 vs. 4194304) 
```

This happens because the scroll response exceeds the default gRPC max message size (4MB).
This PR increases the default limit and allows it to be customised.

Resolves #30.
