### PR TITLE
chore: Updated a paramter in the Chroma migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration
 | `--qdrant.api-key`        | Qdrant API key. Optional.                                                                                        |
 | `--qdrant.dense-vector`   | Name of the dense vector in Qdrant. Default: `"dense_vector"`                                                    |
 | `--qdrant.id-field`       | Field storing Chroma IDs in Qdrant. Default: `"__id__"`                                                          |
-| `--qdrant.distance`       | Distance metric for the Qdrant collection. `"cosine"`, `"dot"`, `"manhattan"` or `"euclid"`. Default: `"euclid"` |
+| `--qdrant.distance-metric`| Distance metric for the Qdrant collection. `"cosine"`, `"dot"`, `"manhattan"` or `"euclid"`. Default: `"euclid"` |
 | `--qdrant.document-field` | Field storing Chroma documents in Qdrant. Default: `"document"`                                                  |
 
 * See [Shared Migration Options](#shared-migration-options) for common migration parameters.

--- a/cmd/migrate_from_chroma.go
+++ b/cmd/migrate_from_chroma.go
@@ -19,13 +19,13 @@ import (
 )
 
 type MigrateFromChromaCmd struct {
-	Chroma        commons.ChromaConfig    `embed:"" prefix:"chroma."`
-	Qdrant        commons.QdrantConfig    `embed:"" prefix:"qdrant."`
-	Migration     commons.MigrationConfig `embed:"" prefix:"migration."`
-	IdField       string                  `prefix:"qdrant." help:"Field storing Chroma IDs in Qdrant." default:"__id__"`
-	DenseVector   string                  `prefix:"qdrant." help:"Name of the dense vector in Qdrant" default:"dense_vector"`
-	Distance      string                  `prefix:"qdrant." enum:"cosine,dot,euclid,manhattan" help:"Distance metric for the Qdrant collection" default:"euclid"`
-	DocumentField string                  `prefix:"qdrant." help:"Field storing Chroma documents in Qdrant." default:"document"`
+	Chroma         commons.ChromaConfig    `embed:"" prefix:"chroma."`
+	Qdrant         commons.QdrantConfig    `embed:"" prefix:"qdrant."`
+	Migration      commons.MigrationConfig `embed:"" prefix:"migration."`
+	IdField        string                  `prefix:"qdrant." help:"Field storing Chroma IDs in Qdrant." default:"__id__"`
+	DenseVector    string                  `prefix:"qdrant." help:"Name of the dense vector in Qdrant" default:"dense_vector"`
+	DistanceMetric string                  `prefix:"qdrant." enum:"cosine,dot,euclid,manhattan" help:"Distance metric for the Qdrant collection" default:"euclid"`
+	DocumentField  string                  `prefix:"qdrant." help:"Field storing Chroma documents in Qdrant." default:"document"`
 
 	targetHost string
 	targetPort int
@@ -185,7 +185,7 @@ func (r *MigrateFromChromaCmd) prepareTargetCollection(ctx context.Context, coll
 		VectorsConfig: qdrant.NewVectorsConfigMap(map[string]*qdrant.VectorParams{
 			r.DenseVector: {
 				Size:     uint64(collection.Dimension()),
-				Distance: distanceMapping[r.Distance],
+				Distance: distanceMapping[r.DistanceMetric],
 			},
 		}),
 	}

--- a/integration_tests/migrate_from_chroma_test.go
+++ b/integration_tests/migrate_from_chroma_test.go
@@ -97,7 +97,7 @@ func TestMigrateFromChroma(t *testing.T) {
 		fmt.Sprintf("--qdrant.collection=%s", testCollectionName),
 		fmt.Sprintf("--qdrant.id-field=%s", idField),
 		fmt.Sprintf("--qdrant.document-field=%s", documentField),
-		fmt.Sprintf("--qdrant.distance=%s", distance),
+		fmt.Sprintf("--qdrant.distance-metric=%s", distance),
 		fmt.Sprintf("--qdrant.dense-vector=%s", denseVectorField),
 	}
 


### PR DESCRIPTION
The parameter `--qdrant.distance` has been renamed to `--qdrant.distance-metric` in the Chroma migration command to maintain consistency with the Milvus and the PG migration commands.
