### PR TITLE
refactor: Use default vector for Pinecone, Chroma, S3 Vectors

Signed-off-by: Anush008 <anushshetty90@gmail.com>

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration
 | `--qdrant.collection`     | Target collection name.                                                                                          |
 | `--qdrant.url`            | Qdrant gRPC URL. Default: `"http://localhost:6334"`                                                              |
 | `--qdrant.api-key`        | Qdrant API key. Optional.                                                                                        |
-| `--qdrant.dense-vector`   | Name of the dense vector in Qdrant. Default: `"dense_vector"`                                                    |
 | `--qdrant.id-field`       | Field storing Chroma IDs in Qdrant. Default: `"__id__"`                                                          |
 | `--qdrant.distance-metric`| Distance metric for the Qdrant collection. `"cosine"`, `"dot"`, `"manhattan"` or `"euclid"`. Default: `"euclid"` |
 | `--qdrant.document-field` | Field storing Chroma documents in Qdrant. Default: `"document"`                                                  |
@@ -121,7 +120,6 @@ docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration
 | `--qdrant.collection`           | Target collection name                                          |
 | `--qdrant.url`                  | Qdrant gRPC URL. Default: `"http://localhost:6334"`             |
 | `--qdrant.api-key`              | Qdrant API key                                                  |
-| `--qdrant.dense-vector`         | Name of the dense vector in Qdrant. Default: `"dense_vector"`   |
 | `--qdrant.sparse-vector`        | Name of the sparse vector in Qdrant. Default: `"sparse_vector"` |
 | `--qdrant.id-field`             | Field storing Pinecone IDs in Qdrant. Default: `"__id__"`       |
 
@@ -438,7 +436,6 @@ docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration
 | `--qdrant.collection`   | Target collection name                                        |
 | `--qdrant.api-key`      | Qdrant API key (optional)                                     |
 | `--qdrant.id-field`     | Field storing S3 IDs in Qdrant. Default: `"__id__"`           |
-| `--qdrant.dense-vector` | Name of the dense vector in Qdrant. Default: `"dense_vector"` |
 
 * See [Shared Migration Options](#shared-migration-options) for common migration parameters.
 

--- a/cmd/migrate_from_pinecone.go
+++ b/cmd/migrate_from_pinecone.go
@@ -20,7 +20,6 @@ type MigrateFromPineconeCmd struct {
 	Qdrant       commons.QdrantConfig    `embed:"" prefix:"qdrant."`
 	Migration    commons.MigrationConfig `embed:"" prefix:"migration."`
 	IdField      string                  `prefix:"qdrant." help:"Field storing Pinecone IDs in Qdrant." default:"__id__"`
-	DenseVector  string                  `prefix:"qdrant." help:"Name of the dense vector in Qdrant" default:"dense_vector"`
 	SparseVector string                  `prefix:"qdrant." help:"Name of the sparse vector in Qdrant" default:"sparse_vector"`
 
 	targetHost string
@@ -171,11 +170,9 @@ func (r *MigrateFromPineconeCmd) prepareTargetCollection(ctx context.Context, so
 	case "dense":
 		createReq = &qdrant.CreateCollection{
 			CollectionName: r.Qdrant.Collection,
-			VectorsConfig: qdrant.NewVectorsConfigMap(map[string]*qdrant.VectorParams{
-				r.DenseVector: {
-					Size:     uint64(*foundIndex.Dimension),
-					Distance: distanceMapping[foundIndex.Metric],
-				},
+			VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+				Size:     uint64(*foundIndex.Dimension),
+				Distance: distanceMapping[foundIndex.Metric],
 			}),
 		}
 	case "sparse":
@@ -256,7 +253,7 @@ func (r *MigrateFromPineconeCmd) migrateData(ctx context.Context, sourceIndexCon
 			vectorMap := make(map[string]*qdrant.Vector)
 
 			if vec.Values != nil {
-				vectorMap[r.DenseVector] = qdrant.NewVectorDense(*vec.Values)
+				vectorMap[""] = qdrant.NewVectorDense(*vec.Values)
 			}
 
 			if vec.SparseValues != nil {

--- a/cmd/migrate_from_s3_vectors.go
+++ b/cmd/migrate_from_s3_vectors.go
@@ -19,11 +19,10 @@ import (
 )
 
 type MigrateFromS3VectorsCmd struct {
-	S3          commons.S3VectorsConfig `embed:"" prefix:"s3."`
-	Qdrant      commons.QdrantConfig    `embed:"" prefix:"qdrant."`
-	Migration   commons.MigrationConfig `embed:"" prefix:"migration."`
-	IdField     string                  `prefix:"qdrant." help:"Field storing S3 IDs in Qdrant." default:"__id__"`
-	DenseVector string                  `prefix:"qdrant." help:"Name of the dense vector in Qdrant" default:"dense_vector"`
+	S3        commons.S3VectorsConfig `embed:"" prefix:"s3."`
+	Qdrant    commons.QdrantConfig    `embed:"" prefix:"qdrant."`
+	Migration commons.MigrationConfig `embed:"" prefix:"migration."`
+	IdField   string                  `prefix:"qdrant." help:"Field storing S3 IDs in Qdrant." default:"__id__"`
 
 	targetHost string
 	targetPort int
@@ -140,11 +139,9 @@ func (r *MigrateFromS3VectorsCmd) prepareTargetCollection(ctx context.Context, s
 
 	createReq := &qdrant.CreateCollection{
 		CollectionName: r.Qdrant.Collection,
-		VectorsConfig: qdrant.NewVectorsConfigMap(map[string]*qdrant.VectorParams{
-			r.DenseVector: {
-				Size:     uint64(*indexInfo.Index.Dimension),
-				Distance: dist,
-			},
+		VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+			Size:     uint64(*indexInfo.Index.Dimension),
+			Distance: dist,
 		}),
 	}
 
@@ -212,10 +209,7 @@ func (r *MigrateFromS3VectorsCmd) migrateData(ctx context.Context, sourceClient 
 				return fmt.Errorf("unexpected vector data type")
 			}
 
-			vectorMap := map[string]*qdrant.Vector{
-				r.DenseVector: qdrant.NewVector(vData.Value...),
-			}
-			point.Vectors = qdrant.NewVectorsMap(vectorMap)
+			point.Vectors = qdrant.NewVectorsDense(vData.Value)
 
 			payload := make(map[string]*qdrant.Value)
 			if vec.Metadata != nil {

--- a/integration_tests/commons_test.go
+++ b/integration_tests/commons_test.go
@@ -16,7 +16,6 @@ const (
 	totalEntries       = 100
 	dimension          = 384
 	idField            = "__id__"
-	denseVectorField   = "dense_vector"
 )
 
 func randFloat32Values(n int) []float32 {

--- a/integration_tests/migrate_from_chroma_test.go
+++ b/integration_tests/migrate_from_chroma_test.go
@@ -97,7 +97,6 @@ func TestMigrateFromChroma(t *testing.T) {
 		fmt.Sprintf("--qdrant.id-field=%s", idField),
 		fmt.Sprintf("--qdrant.document-field=%s", documentField),
 		fmt.Sprintf("--qdrant.distance-metric=%s", distance),
-		fmt.Sprintf("--qdrant.dense-vector=%s", denseVectorField),
 	}
 
 	runMigrationBinary(t, args)
@@ -138,7 +137,7 @@ func TestMigrateFromChroma(t *testing.T) {
 		require.Equal(t, expected.document, point.Payload[documentField].GetStringValue())
 		require.Equal(t, expected.source, point.Payload[sourceField].GetStringValue())
 
-		vector := point.Vectors.GetVectors().GetVectors()[denseVectorField].GetData()
+		vector := point.Vectors.GetVector().GetData()
 		require.Equal(t, expected.vector, vector)
 	}
 }

--- a/integration_tests/migrate_from_pinecone_test.go
+++ b/integration_tests/migrate_from_pinecone_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	denseVectorName  = "dense_vector"
 	sparseVectorName = "sparse_vector"
 )
 
@@ -71,7 +70,6 @@ func TestMigrateFromPineconeDense(t *testing.T) {
 		fmt.Sprintf("--qdrant.api-key=%s", qdrantAPIKey),
 		fmt.Sprintf("--qdrant.collection=%s", testCollectionName),
 		fmt.Sprintf("--qdrant.id-field=%s", idField),
-		fmt.Sprintf("--qdrant.dense-vector=%s", denseVectorName),
 	}
 
 	runMigrationBinary(t, args)
@@ -106,7 +104,7 @@ func TestMigrateFromPineconeDense(t *testing.T) {
 
 		require.Equal(t, expected.source, point.Payload["source"].GetStringValue())
 
-		vector := point.Vectors.GetVectors().GetVectors()[denseVectorName].GetData()
+		vector := point.Vectors.GetVector().GetData()
 		require.Equal(t, expected.vector, vector)
 	}
 }

--- a/integration_tests/migrate_from_s3_vectors_test.go
+++ b/integration_tests/migrate_from_s3_vectors_test.go
@@ -123,7 +123,6 @@ func TestMigrateFromS3Vectors(t *testing.T) {
 		fmt.Sprintf("--qdrant.collection=%s", testCollectionName),
 		fmt.Sprintf("--qdrant.api-key=%s", qdrantAPIKey),
 		fmt.Sprintf("--qdrant.id-field=%s", idField),
-		fmt.Sprintf("--qdrant.dense-vector=%s", denseVectorField),
 	}
 	runMigrationBinary(t, args)
 
@@ -166,7 +165,7 @@ func TestMigrateFromS3Vectors(t *testing.T) {
 		require.Equal(t, exp.name, payload["name"].GetStringValue())
 		require.Equal(t, exp.city, payload["city"].GetStringValue())
 		require.Equal(t, exp.age, payload["age"].GetIntegerValue())
-		vector := point.Vectors.GetVectors().GetVectors()[denseVectorField].GetData()
+		vector := point.Vectors.GetVector().GetData()
 		require.Equal(t, exp.vector, vector)
 	}
 }


### PR DESCRIPTION
Pinecone, Chroma, S3 vectors only support one dense vector per entry.
It is equivalent to the default(unnamed) vector of a Qdrant collection.

With this PR, when migrating from one of those sources, the default(unnamed) vector is used instead of a named one.

A practical benefit being, when searching, you don't have to specify the vector name. The default vector is used.