### PR TITLE
feat: Support migrating from a custom sharded collection

### DIFF
--- a/integration_tests/image_test.go
+++ b/integration_tests/image_test.go
@@ -17,8 +17,10 @@ func qdrantContainer(ctx context.Context, t *testing.T, apiKey string) testconta
 		Image:        "qdrant/qdrant:v1.14.1",
 		ExposedPorts: []string{"6334/tcp"},
 		Env: map[string]string{
+			"QDRANT__CLUSTER__ENABLED": "true",
 			"QDRANT__SERVICE__API_KEY": apiKey,
 		},
+		Cmd: []string{"./qdrant", "--uri", "http://qdrant_node_1:6335"},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("6334/tcp").WithStartupTimeout(5 * time.Second),
 		),

--- a/integration_tests/migrate_from_qdrant_custom_sharding_test.go
+++ b/integration_tests/migrate_from_qdrant_custom_sharding_test.go
@@ -1,0 +1,156 @@
+package integrationtests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+func TestMigrateFromQdrantWithShardKeys(t *testing.T) {
+	ctx := context.Background()
+
+	sourceContainer := qdrantContainer(ctx, t, qdrantAPIKey)
+	defer func() {
+		if err := sourceContainer.Terminate(ctx); err != nil {
+			t.Errorf("Failed to terminate source Qdrant container: %v", err)
+		}
+	}()
+
+	targetContainer := qdrantContainer(ctx, t, qdrantAPIKey)
+	defer func() {
+		if err := targetContainer.Terminate(ctx); err != nil {
+			t.Errorf("Failed to terminate target Qdrant container: %v", err)
+		}
+	}()
+
+	sourceHost, err := sourceContainer.Host(ctx)
+	require.NoError(t, err)
+	sourcePort, err := sourceContainer.MappedPort(ctx, qdrantGRPCPort)
+	require.NoError(t, err)
+
+	targetHost, err := targetContainer.Host(ctx)
+	require.NoError(t, err)
+	targetPort, err := targetContainer.MappedPort(ctx, qdrantGRPCPort)
+	require.NoError(t, err)
+
+	sourceClient, err := qdrant.NewClient(&qdrant.Config{
+		Host:                   sourceHost,
+		Port:                   sourcePort.Int(),
+		APIKey:                 qdrantAPIKey,
+		SkipCompatibilityCheck: true,
+	})
+	require.NoError(t, err)
+	defer sourceClient.Close()
+
+	targetClient, err := qdrant.NewClient(&qdrant.Config{
+		Host:                   targetHost,
+		Port:                   targetPort.Int(),
+		APIKey:                 qdrantAPIKey,
+		SkipCompatibilityCheck: true,
+	})
+	require.NoError(t, err)
+	defer targetClient.Close()
+
+	sourceCollectionName := "source_collection"
+	targetCollectionName := "target_collection"
+
+	err = sourceClient.CreateCollection(ctx, &qdrant.CreateCollection{
+		CollectionName: sourceCollectionName,
+		VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+			Size:     dimension,
+			Distance: qdrant.Distance_Dot,
+		}),
+		ShardingMethod: qdrant.ShardingMethod_Custom.Enum(),
+		ShardNumber:    qdrant.PtrOf(uint32(2)),
+	})
+	require.NoError(t, err)
+
+	shardKeys := []string{"shard_a", "shard_b"}
+
+	for _, shardKey := range shardKeys {
+		err = sourceClient.CreateShardKey(ctx, sourceCollectionName, &qdrant.CreateShardKey{
+			ShardKey: qdrant.NewShardKey(shardKey),
+		})
+		require.NoError(t, err)
+	}
+	pointsByShard := make(map[string][]*qdrant.PointStruct)
+
+	expectedPointsByID := make(map[string][]float32)
+
+	for _, shardKey := range shardKeys {
+		points := make([]*qdrant.PointStruct, 0)
+		for i := 0; i < totalEntries/2; i++ {
+			pointID := uuid.New().String()
+			vector := randFloat32Values(dimension)
+			expectedPointsByID[pointID] = vector
+
+			points = append(points, &qdrant.PointStruct{
+				Id:      qdrant.NewID(pointID),
+				Vectors: qdrant.NewVectors(vector...),
+				Payload: qdrant.NewValueMap(map[string]any{
+					"shard": shardKey,
+				}),
+			})
+		}
+		pointsByShard[shardKey] = points
+
+		_, err = sourceClient.Upsert(ctx, &qdrant.UpsertPoints{
+			CollectionName: sourceCollectionName,
+			Points:         points,
+			ShardKeySelector: &qdrant.ShardKeySelector{
+				ShardKeys: []*qdrant.ShardKey{qdrant.NewShardKey(shardKey)},
+			},
+			Wait: qdrant.PtrOf(true),
+		})
+		require.NoError(t, err)
+	}
+
+	args := []string{
+		"qdrant",
+		fmt.Sprintf("--source.url=http://%s:%s", sourceHost, sourcePort.Port()),
+		fmt.Sprintf("--source.api-key=%s", qdrantAPIKey),
+		fmt.Sprintf("--source.collection=%s", sourceCollectionName),
+		fmt.Sprintf("--target.url=http://%s:%s", targetHost, targetPort.Port()),
+		fmt.Sprintf("--target.api-key=%s", qdrantAPIKey),
+		fmt.Sprintf("--target.collection=%s", targetCollectionName),
+		"--migration.create-collection=true",
+	}
+
+	runMigrationBinary(t, args)
+
+	targetCountResp, err := targetClient.Count(ctx, &qdrant.CountPoints{
+		CollectionName: targetCollectionName,
+		Exact:          qdrant.PtrOf(true),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(totalEntries), targetCountResp)
+
+	for _, shardKey := range shardKeys {
+		points, err := targetClient.Scroll(ctx, &qdrant.ScrollPoints{
+			CollectionName: targetCollectionName,
+			Limit:          qdrant.PtrOf(uint32(totalEntries)),
+			WithPayload:    qdrant.NewWithPayload(true),
+			WithVectors:    qdrant.NewWithVectors(true),
+			ShardKeySelector: &qdrant.ShardKeySelector{
+				ShardKeys: []*qdrant.ShardKey{qdrant.NewShardKey(shardKey)},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, points, totalEntries/2)
+
+		for _, point := range points {
+			require.Equal(t, shardKey, point.GetShardKey().GetKeyword())
+			require.Equal(t, shardKey, point.Payload["shard"].GetStringValue())
+
+			pointID := point.Id.GetUuid()
+			expectedVector := expectedPointsByID[pointID]
+			actualVector := point.Vectors.GetVector().GetData()
+			require.Equal(t, expectedVector, actualVector)
+		}
+	}
+}


### PR DESCRIPTION
## Description

- Updated `migrateData()` so it now gets shard keys from points while scrolling.
- For each scrolled batch, points are now grouped by shard key and upserted one group at a time with the right shard key.
- Shard keys are automatically created on the target collection on-demand as they're encountered. Skipped if they already exist.
- Added integration tests.


Collections without custom sharding work exactly as before.