### PR TITLE
chore: Bump Go version to 1.25.5

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.5'
           cache: false
 
       - name: Check Go Formatting
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.5'
           cache-dependency-path: go.sum
 
       - uses: actions/setup-python@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qdrant/migration
 
-go 1.25
+go 1.25.5
 
 require (
 	github.com/alecthomas/kong v1.13.0


### PR DESCRIPTION
## Fixes

<img width="954" height="236" alt="Screenshot 2025-12-09 at 2 13 44 PM" src="https://github.com/user-attachments/assets/7e6f84d8-5e68-4a47-8880-9a7e2f62c7c5" />
