### PR TITLE
refactor: PG UUID columns handling

### DIFF
--- a/integration_tests/migrate_from_pg_test.go
+++ b/integration_tests/migrate_from_pg_test.go
@@ -84,7 +84,7 @@ func TestMigrateFromPG(t *testing.T) {
 }
 
 func TestMigrateFromPGParallel(t *testing.T) {
-	testMigrateFromPG(t, "test_collection_parallel", 4)
+	testMigrateFromPG(t, testCollectionName, 4)
 }
 
 func setupPGTable(ctx context.Context, t *testing.T, connStr string) []pgEntry {


### PR DESCRIPTION
## Description

If the column type in a Postgres table is UUID, it is returned as `[16]byte`. So we need to handle it explicitly when uploading to Qdrant as payload.