### PR TITLE
fix: Support for any stringified ID in Milvus migration

### DIFF
--- a/cmd/migrate_from_milvus.go
+++ b/cmd/migrate_from_milvus.go
@@ -270,9 +270,9 @@ func (r *MigrateFromMilvusCmd) migrateData(ctx context.Context, sourceClient *mi
 				if fieldName == pkName {
 					switch col.Type() {
 					case entity.FieldTypeVarChar:
-						uuid := value.(string)
-						offsetID = qdrant.NewID(uuid)
-						point.Id = offsetID
+						str := value.(string)
+						offsetID = qdrant.NewID(str)
+						point.Id = arbitraryIDToUUID(str)
 					case entity.FieldTypeInt64:
 						num := value.(int64)
 						offsetID = qdrant.NewIDNum(uint64(num))


### PR DESCRIPTION
Fixes #275 

When a Milvus collection has a VarChar PK with non-UUID string values (e.g. numeric strings like `"1980941545339129858"`), the migration fails because the raw string is passed directly to Qdrant as a UUID-type point ID.

Use the existing `arbitraryIDToUUID` helper, it passes valid UUIDs through unchanged and creates a deterministic UUID for everything else.