### PR TITLE
fix: Add the ability to skip existing points

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,9 +620,10 @@ NOTE: If the target collection already exists, its vector size and dimensions mu
 
 #### Additional Options
 
-| Flag                              | Description                                                    |
-| --------------------------------- | -------------------------------------------------------------- |
-| `--migration.num-workers`         | Number of parallel workers to use. Default: Number of CPU cores|
+| Flag                              | Description                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `--migration.num-workers`         | Number of parallel workers to use. Default: Number of CPU cores                                                                     |
+| `--migration.skip-existing`       | Skip points whose IDs already exist in the target collection. Adds one read RPC per batch. Useful when re-running against a partially-populated target. Default: `false` |
 
 See [Shared Migration Options](#shared-migration-options) for shared parameters.
 

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -31,6 +31,7 @@ type MigrateFromQdrantCmd struct {
 	MaxMessageSize       int                     `help:"Maximum gRPC message size in bytes (default: 33554432 = 32MB)" default:"33554432" prefix:"source."`
 	EnsurePayloadIndexes bool                    `help:"Ensure payload indexes from the source are created on the target" default:"true" prefix:"target."`
 	NumWorkers           int                     `help:"Number of parallel workers for data migration (0 = number of CPU cores)" default:"0" prefix:"migration."`
+	SkipExisting         bool                    `help:"Skip points that already exist in the target collection" default:"false" prefix:"migration."`
 
 	sourceHost string
 	sourcePort int
@@ -331,7 +332,7 @@ func (r *MigrateFromQdrantCmd) samplePointIDs(ctx context.Context, client *qdran
 // processBatch handles the upserting of a batch of points to the target collection.
 // It deals with sharding by creating shard keys if they don't exist and retries on transient errors.
 func (r *MigrateFromQdrantCmd) processBatch(ctx context.Context, points []*qdrant.RetrievedPoint, targetClient *qdrant.Client, targetCollection string, shardKeys *sync.Map, wait bool) error {
-	if r.Migration.SkipExisting && len(points) > 0 {
+	if r.SkipExisting && len(points) > 0 {
 		ids := make([]*qdrant.PointId, len(points))
 		for i, p := range points {
 			ids[i] = p.Id

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -346,19 +347,16 @@ func (r *MigrateFromQdrantCmd) processBatch(ctx context.Context, points []*qdran
 		if err != nil {
 			return fmt.Errorf("failed to check existing points: %w", err)
 		}
-		if len(found) > 0 {
-			existing := make(map[string]struct{}, len(found))
-			for _, p := range found {
-				existing[pointIDKey(p.Id)] = struct{}{}
-			}
-			filtered := points[:0]
-			for _, p := range points {
-				if _, ok := existing[pointIDKey(p.Id)]; !ok {
-					filtered = append(filtered, p)
-				}
-			}
-			points = filtered
+
+		existing := make(map[string]struct{}, len(found))
+		for _, p := range found {
+			existing[pointIDKey(p.Id)] = struct{}{}
 		}
+		points = slices.DeleteFunc(points, func(p *qdrant.RetrievedPoint) bool {
+			_, ok := existing[pointIDKey(p.Id)]
+			return ok
+		})
+
 		if len(points) == 0 {
 			return nil
 		}

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -235,6 +235,14 @@ type rangeSpec struct {
 	end   *qdrant.PointId
 }
 
+// pointIDKey returns a stable string key for use in maps.
+func pointIDKey(id *qdrant.PointId) string {
+	if uuid := id.GetUuid(); uuid != "" {
+		return uuid
+	}
+	return fmt.Sprintf("%d", id.GetNum())
+}
+
 // comparePointIDs returns true if a < b.
 // Usually Qdrant collections use either numeric or UUID IDs, not both.
 // If mixed, numeric IDs (a.GetUuid() == "") sort before UUIDs since "" < any non-empty string.
@@ -323,6 +331,38 @@ func (r *MigrateFromQdrantCmd) samplePointIDs(ctx context.Context, client *qdran
 // processBatch handles the upserting of a batch of points to the target collection.
 // It deals with sharding by creating shard keys if they don't exist and retries on transient errors.
 func (r *MigrateFromQdrantCmd) processBatch(ctx context.Context, points []*qdrant.RetrievedPoint, targetClient *qdrant.Client, targetCollection string, shardKeys *sync.Map, wait bool) error {
+	if r.Migration.SkipExisting && len(points) > 0 {
+		ids := make([]*qdrant.PointId, len(points))
+		for i, p := range points {
+			ids[i] = p.Id
+		}
+		found, err := targetClient.Get(ctx, &qdrant.GetPoints{
+			CollectionName: targetCollection,
+			Ids:            ids,
+			WithPayload:    qdrant.NewWithPayload(false),
+			WithVectors:    qdrant.NewWithVectors(false),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to check existing points: %w", err)
+		}
+		if len(found) > 0 {
+			existing := make(map[string]struct{}, len(found))
+			for _, p := range found {
+				existing[pointIDKey(p.Id)] = struct{}{}
+			}
+			filtered := points[:0]
+			for _, p := range points {
+				if _, ok := existing[pointIDKey(p.Id)]; !ok {
+					filtered = append(filtered, p)
+				}
+			}
+			points = filtered
+		}
+		if len(points) == 0 {
+			return nil
+		}
+	}
+
 	// Group points by their shard key.
 	byShardKey := make(map[string][]*qdrant.PointStruct)
 	shardKeyObjs := make(map[string]*qdrant.ShardKey)

--- a/pkg/commons/config.go
+++ b/pkg/commons/config.go
@@ -12,6 +12,7 @@ type MigrationConfig struct {
 	CreateCollection  bool   `short:"c" help:"Create the collection if it does not exist" default:"true"`
 	OffsetsCollection string `help:"Collection to store the current migration offset" default:"_migration_offsets"`
 	BatchDelay        int    `help:"Delay between batches in milliseconds (useful for rate limiting)" default:"0"`
+	SkipExisting      bool   `help:"Skip points that already exist in the target collection" default:"false"`
 }
 
 type MilvusConfig struct {

--- a/pkg/commons/config.go
+++ b/pkg/commons/config.go
@@ -12,7 +12,6 @@ type MigrationConfig struct {
 	CreateCollection  bool   `short:"c" help:"Create the collection if it does not exist" default:"true"`
 	OffsetsCollection string `help:"Collection to store the current migration offset" default:"_migration_offsets"`
 	BatchDelay        int    `help:"Delay between batches in milliseconds (useful for rate limiting)" default:"0"`
-	SkipExisting      bool   `help:"Skip points that already exist in the target collection" default:"false"`
 }
 
 type MilvusConfig struct {


### PR DESCRIPTION
Migrating or syncing large *active* collections will inherently miss some points that are upserted during the migration (if a UUID is upserted behind the migration progress). Therefore, a second migration pass can clean these up. The proposed PR adds a a skip-existing flag that, when activated, will sync any missed points but avoid re-upserting al lthe existing points in the database. 

As a secondary feature, this can be a component of a syncing mechanism that keeps various databases synced between regions. 

*The code changes for this PR were generated using AI*

Claude's description/doc:

```
--migration.skip-existing
Add this flag when running a Qdrant-to-Qdrant migration against a target that already has some (or all) of the data:


docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration qdrant \
    --source.url 'http://source-hostname:6334' \
    --source.collection 'source-collection' \
    --target.url 'https://example.qdrant.io:6334' \
    --target.api-key 'qdrant-key' \
    --target.collection 'target-collection' \
    --migration.skip-existing
What it does: Before each batch upsert, fetches the batch's point IDs from the target (no vectors/payload — lightweight). Any IDs already present are filtered out; only new points are upserted.

When to use it:

Re-running a migration that previously completed, where you want to avoid overwriting target data
Target collection was pre-populated from another source and you want additive-only behavior
When not to use it:

Fresh migrations (nothing in the target) — adds one extra read RPC per batch with no benefit
You want the source to overwrite stale target data (default upsert behavior)
Cost: One extra read RPC to the target per batch. With the default batch size of 50, this doubles the number of target RPCs.
```