### PR TITLE
fix: qdrant-to-qdrant migration crashing on hybrid collections

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: false
 
       - name: Check Go Formatting
@@ -27,7 +27,7 @@ jobs:
       - name: Golang CI Lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.6.2 # Specify the golangci-lint version, so we are stable
+          version: v2.12.2 # Specify the golangci-lint version, so we are stable
           args: --timeout 10m # Increase the timeout to 10 minutes
 
   tests:
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache-dependency-path: go.sum
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,6 @@ linters:
     - containedctx
     - contextcheck
     - errorlint
-    - goconst
     - godot
     - importas
     - nilerr

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
 ARG BUILDKIT_SBOM_SCAN_STAGE=builder
-FROM registry.suse.com/bci/golang:1.25 AS builder
+FROM registry.suse.com/bci/golang:1.26 AS builder
 
 ARG VERSION
 ARG BUILD

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -253,6 +253,7 @@ func comparePointIDs(a, b *qdrant.PointId) bool {
 }
 
 // convertVector converts a VectorOutput from a retrieved point to a Vector for upserting.
+// Returns nil if the vector is absent, empty, or of an unrecognized type.
 func convertVector(v *qdrant.VectorOutput) *qdrant.Vector {
 	if v == nil {
 		return nil
@@ -265,7 +266,11 @@ func convertVector(v *qdrant.VectorOutput) *qdrant.Vector {
 	}
 	// Important: this should be a fallback option, as everything can be interpreted as dense vectors.
 	if dense := v.GetDenseVector(); dense != nil {
-		return qdrant.NewVectorDense(dense.GetData())
+		data := dense.GetData()
+		if len(data) == 0 {
+			return nil
+		}
+		return qdrant.NewVectorDense(data)
 	}
 	return nil
 }
@@ -281,7 +286,9 @@ func convertVectors(p *qdrant.RetrievedPoint) *qdrant.Vectors {
 	if vs := p.Vectors.GetVectors(); vs != nil {
 		named := make(map[string]*qdrant.Vector, len(vs.GetVectors()))
 		for k, v := range vs.GetVectors() {
-			named[k] = convertVector(v)
+			if cv := convertVector(v); cv != nil {
+				named[k] = cv
+			}
 		}
 		return qdrant.NewVectorsMap(named)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qdrant/migration
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/alecthomas/kong v1.13.0


### PR DESCRIPTION
## Description

Qdrant-to-qdrant migrations of hybrid collections (multiple named dense + sparse vectors) crashed with `dense vector must not be empty`.

### Cause

When the source server sends `VectorOutput{Dense: &DenseVector{}}` as a placeholder for an absent vector, the old code passed that directly to `NewVectorDense(nil)`, producing `Vector{dense:{data:[]}}` on the wire. An explicitly typed but empty dense vector, which the server rejects

### Fix

Skip empty dense vectors in `convertVector()`. Filter nils from the named map in `convertVectors()`.

## Go Version Bump

This PR also bumps the Go version to v1.26 to resolve the vulnerability reported ain https://github.com/qdrant/migration/actions/runs/27265480843/job/80521391831.