### PR TITLE
feat: support target shard key routing for Qdrant migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,34 @@ docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration
     --migration.batch-size 64
 ```
 
+#### Custom Sharding Support
+
+If the source collection uses custom sharding, the migration preserves each point's shard key and creates the corresponding shard keys on the target.
+The routing options below override the source shard keys when specified.
+
+To migrate all points into a specific keyword shard key on a custom-sharded
+target, pass the key directly:
+
+```bash
+docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration qdrant \
+    --source.url 'http://source-hostname:6334' \
+    --source.collection 'source-collection' \
+    --target.url 'https://target-hostname:6334' \
+    --target.collection 'target-collection' \
+    --target.shard-key 'tier-a'
+```
+
+To route each point by a string or non-negative integer payload field instead, use `--target.shard-key-field`:
+
+```bash
+docker run --net=host --rm -it registry.cloud.qdrant.io/library/qdrant-migration qdrant \
+    --source.url 'http://source-hostname:6334' \
+    --source.collection 'source-collection' \
+    --target.url 'https://target-hostname:6334' \
+    --target.collection 'target-collection' \
+    --target.shard-key-field 'tenant_tier'
+```
+
 NOTE: If the target collection already exists, its vector size and dimensions must match the source. Other settings like replication, shards can differ.
 
 #### Source Qdrant Options
@@ -617,6 +645,8 @@ NOTE: If the target collection already exists, its vector size and dimensions mu
 | `--target.url`                    | Target gRPC URL. Default: `"http://localhost:6334"` |
 | `--target.api-key`                | API key for target instance                         |
 | `--target.ensure-payload-indexes` | Ensure payload indexes exist. Default: true         |
+| `--target.shard-key`              | Fixed keyword shard key used for every target upsert |
+| `--target.shard-key-field`        | Payload field used as each point's target shard key  |
 
 #### Additional Options
 

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -30,6 +30,8 @@ type MigrateFromQdrantCmd struct {
 	Migration            commons.MigrationConfig `embed:"" prefix:"migration."`
 	MaxMessageSize       int                     `help:"Maximum gRPC message size in bytes (default: 33554432 = 32MB)" default:"33554432" prefix:"source."`
 	EnsurePayloadIndexes bool                    `help:"Ensure payload indexes from the source are created on the target" default:"true" prefix:"target."`
+	ShardKey             string                  `help:"Fixed keyword shard key used for every target upsert" prefix:"target."`
+	ShardKeyField        string                  `help:"Payload field used as the target shard key for each point" prefix:"target."`
 	NumWorkers           int                     `help:"Number of parallel workers for data migration (0 = number of CPU cores)" default:"0" prefix:"migration."`
 
 	sourceHost string
@@ -54,6 +56,9 @@ func (r *MigrateFromQdrantCmd) Parse() error {
 }
 
 func (r *MigrateFromQdrantCmd) Validate() error {
+	if r.ShardKey != "" && r.ShardKeyField != "" {
+		return fmt.Errorf("target shard-key and shard-key-field cannot be used together")
+	}
 	return validateBatchSize(r.Migration.BatchSize)
 }
 
@@ -152,6 +157,10 @@ func (r *MigrateFromQdrantCmd) prepareTargetCollection(ctx context.Context, sour
 			pterm.Info.Printfln("Target collection '%s' already exists. Skipping creation.", targetCollection)
 		} else {
 			params := sourceCollectionInfo.Config.GetParams()
+			shardingMethod := params.ShardingMethod
+			if r.ShardKey != "" || r.ShardKeyField != "" {
+				shardingMethod = qdrant.PtrOf(qdrant.ShardingMethod_Custom)
+			}
 			if err := targetClient.CreateCollection(ctx, &qdrant.CreateCollection{
 				CollectionName:         targetCollection,
 				HnswConfig:             sourceCollectionInfo.Config.GetHnswConfig(),
@@ -163,7 +172,7 @@ func (r *MigrateFromQdrantCmd) prepareTargetCollection(ctx context.Context, sour
 				ReplicationFactor:      params.ReplicationFactor,
 				WriteConsistencyFactor: params.WriteConsistencyFactor,
 				QuantizationConfig:     sourceCollectionInfo.Config.GetQuantizationConfig(),
-				ShardingMethod:         params.ShardingMethod,
+				ShardingMethod:         shardingMethod,
 				SparseVectorsConfig:    params.SparseVectorsConfig,
 				StrictModeConfig:       sourceCollectionInfo.Config.GetStrictModeConfig(),
 			}); err != nil {
@@ -171,7 +180,6 @@ func (r *MigrateFromQdrantCmd) prepareTargetCollection(ctx context.Context, sour
 			}
 		}
 	}
-
 	targetCollectionInfo, err := targetClient.GetCollectionInfo(ctx, targetCollection)
 	if err != nil {
 		return fmt.Errorf("failed to get target collection information: %w", err)
@@ -295,6 +303,27 @@ func convertVectors(p *qdrant.RetrievedPoint) *qdrant.Vectors {
 	return nil
 }
 
+func (r *MigrateFromQdrantCmd) targetShardKey(point *qdrant.RetrievedPoint) (*qdrant.ShardKey, error) {
+	if r.ShardKey != "" {
+		return qdrant.NewShardKeyKeyword(r.ShardKey), nil
+	}
+	if r.ShardKeyField == "" {
+		return point.GetShardKey(), nil
+	}
+
+	value := point.GetPayload()[r.ShardKeyField]
+	if value == nil {
+		return nil, fmt.Errorf("payload field %q is missing", r.ShardKeyField)
+	}
+	if keyword, ok := value.GetKind().(*qdrant.Value_StringValue); ok && keyword.StringValue != "" {
+		return qdrant.NewShardKeyKeyword(keyword.StringValue), nil
+	}
+	if number, ok := value.GetKind().(*qdrant.Value_IntegerValue); ok && number.IntegerValue >= 0 {
+		return qdrant.NewShardKeyNum(uint64(number.IntegerValue)), nil
+	}
+	return nil, fmt.Errorf("payload field %q must be a non-empty string or non-negative integer", r.ShardKeyField)
+}
+
 // samplePointIDs fetches a random sample of point IDs from the source collection.
 // These IDs are used as boundaries to divide the migration work among parallel workers.
 func (r *MigrateFromQdrantCmd) samplePointIDs(ctx context.Context, client *qdrant.Client, collection string, pointCount uint64) ([]*qdrant.PointId, error) {
@@ -328,22 +357,21 @@ func (r *MigrateFromQdrantCmd) samplePointIDs(ctx context.Context, client *qdran
 }
 
 // processBatch handles the upserting of a batch of points to the target collection.
-// It deals with sharding by creating shard keys if they don't exist and retries on transient errors.
+// It preserves source sharding or applies the configured target shard key.
 func (r *MigrateFromQdrantCmd) processBatch(ctx context.Context, points []*qdrant.RetrievedPoint, targetClient *qdrant.Client, targetCollection string, shardKeys *sync.Map, wait bool) error {
 	// Group points by their shard key.
 	byShardKey := make(map[string][]*qdrant.PointStruct)
 	shardKeyObjs := make(map[string]*qdrant.ShardKey)
 
 	for _, p := range points {
+		shardKey, err := r.targetShardKey(p)
+		if err != nil {
+			return fmt.Errorf("cannot route point %v: %w", p.GetId(), err)
+		}
 		key := ""
-		// Determine the shard key for the point.
-		if sk := p.GetShardKey(); sk != nil {
-			if kw := sk.GetKeyword(); kw != "" {
-				key = kw // String-based shard key.
-			} else {
-				key = fmt.Sprintf("%d", sk.GetNumber())
-			}
-			shardKeyObjs[key] = sk
+		if shardKey != nil {
+			key = shardKey.String()
+			shardKeyObjs[key] = shardKey
 		}
 		byShardKey[key] = append(byShardKey[key], &qdrant.PointStruct{
 			Id:      p.Id,
@@ -360,7 +388,6 @@ func (r *MigrateFromQdrantCmd) processBatch(ctx context.Context, points []*qdran
 			Wait:           qdrant.PtrOf(wait),
 		}
 		if key != "" {
-			// If the shard key is new, create it on the target collection.
 			if _, ok := shardKeys.Load(key); !ok {
 				err := targetClient.CreateShardKey(ctx, targetCollection, &qdrant.CreateShardKey{ShardKey: shardKeyObjs[key]})
 				if err != nil && !strings.Contains(err.Error(), "already exists") {
@@ -368,7 +395,6 @@ func (r *MigrateFromQdrantCmd) processBatch(ctx context.Context, points []*qdran
 				}
 				shardKeys.Store(key, true)
 			}
-			// Specify the shard key for the upsert request.
 			req.ShardKeySelector = &qdrant.ShardKeySelector{ShardKeys: []*qdrant.ShardKey{shardKeyObjs[key]}}
 		}
 		if err := upsertWithRetry(ctx, targetClient, req); err != nil {
@@ -403,7 +429,6 @@ func (r *MigrateFromQdrantCmd) migrateDataSequential(ctx context.Context, source
 	bar, _ := pterm.DefaultProgressbar.WithTotal(int(sourcePointCount)).Start()
 	displayMigrationProgress(bar, count)
 	shardKeys := &sync.Map{}
-
 	for {
 		// Scroll through points from the source collection in batches.
 		resp, err := sourceClient.GetPointsClient().Scroll(ctx, &qdrant.ScrollPoints{

--- a/cmd/migrate_from_qdrant.go
+++ b/cmd/migrate_from_qdrant.go
@@ -62,6 +62,10 @@ func (r *MigrateFromQdrantCmd) Validate() error {
 	return validateBatchSize(r.Migration.BatchSize)
 }
 
+func (r *MigrateFromQdrantCmd) routesToTargetShard() bool {
+	return r.ShardKey != "" || r.ShardKeyField != ""
+}
+
 func (r *MigrateFromQdrantCmd) ValidateParsedValues() error {
 	if r.sourceHost == r.targetHost && r.sourcePort == r.targetPort && r.Source.Collection == r.Target.Collection {
 		return fmt.Errorf("source and target collections must be different")
@@ -158,7 +162,7 @@ func (r *MigrateFromQdrantCmd) prepareTargetCollection(ctx context.Context, sour
 		} else {
 			params := sourceCollectionInfo.Config.GetParams()
 			shardingMethod := params.ShardingMethod
-			if r.ShardKey != "" || r.ShardKeyField != "" {
+			if r.routesToTargetShard() {
 				shardingMethod = qdrant.PtrOf(qdrant.ShardingMethod_Custom)
 			}
 			if err := targetClient.CreateCollection(ctx, &qdrant.CreateCollection{
@@ -183,6 +187,9 @@ func (r *MigrateFromQdrantCmd) prepareTargetCollection(ctx context.Context, sour
 	targetCollectionInfo, err := targetClient.GetCollectionInfo(ctx, targetCollection)
 	if err != nil {
 		return fmt.Errorf("failed to get target collection information: %w", err)
+	}
+	if r.routesToTargetShard() && targetCollectionInfo.GetConfig().GetParams().GetShardingMethod() != qdrant.ShardingMethod_Custom {
+		return fmt.Errorf("target collection %q must use custom sharding when a target shard key is configured", targetCollection)
 	}
 
 	// If EnsurePayloadIndexes is enabled, create any missing payload indexes on the target.

--- a/integration_tests/migrate_from_qdrant_custom_sharding_test.go
+++ b/integration_tests/migrate_from_qdrant_custom_sharding_test.go
@@ -11,7 +11,12 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targetCollectionName string, numWorkers int, shardKeyField string) {
+type targetShardRouting struct {
+	flag     string
+	fixedKey string
+}
+
+func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targetCollectionName string, numWorkers int, routing targetShardRouting) {
 	ctx := context.Background()
 
 	sourceContainer := qdrantContainer(ctx, t, qdrantAPIKey)
@@ -63,7 +68,7 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 			Distance: qdrant.Distance_Dot,
 		}),
 	}
-	if shardKeyField == "" {
+	if routing.flag == "" {
 		createSource.ShardingMethod = qdrant.ShardingMethod_Custom.Enum()
 	}
 	err = sourceClient.CreateCollection(ctx, createSource)
@@ -71,7 +76,7 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 
 	shardKeys := []string{"shard_a", "shard_b"}
 
-	if shardKeyField == "" {
+	if routing.flag == "" {
 		for _, shardKey := range shardKeys {
 			err = sourceClient.CreateShardKey(ctx, sourceCollectionName, &qdrant.CreateShardKey{
 				ShardKey: qdrant.NewShardKey(shardKey),
@@ -103,7 +108,7 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 			Points:         points,
 			Wait:           qdrant.PtrOf(true),
 		}
-		if shardKeyField == "" {
+		if routing.flag == "" {
 			upsert.ShardKeySelector = &qdrant.ShardKeySelector{
 				ShardKeys: []*qdrant.ShardKey{qdrant.NewShardKey(shardKey)},
 			}
@@ -123,8 +128,8 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 		fmt.Sprintf("--migration.num-workers=%d", numWorkers),
 		"--migration.create-collection=true",
 	}
-	if shardKeyField != "" {
-		args = append(args, fmt.Sprintf("--target.shard-key-field=%s", shardKeyField))
+	if routing.flag != "" {
+		args = append(args, routing.flag)
 	}
 
 	runMigrationBinary(t, args)
@@ -136,7 +141,11 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 	require.NoError(t, err)
 	require.Equal(t, uint64(totalEntries), targetCountResp)
 
-	for _, shardKey := range shardKeys {
+	targetShardKeys := shardKeys
+	if routing.fixedKey != "" {
+		targetShardKeys = []string{routing.fixedKey}
+	}
+	for _, shardKey := range targetShardKeys {
 		points, err := targetClient.Scroll(ctx, &qdrant.ScrollPoints{
 			CollectionName: targetCollectionName,
 			Limit:          qdrant.PtrOf(uint32(totalEntries)),
@@ -147,11 +156,17 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 			},
 		})
 		require.NoError(t, err)
-		require.Len(t, points, totalEntries/2)
+		expectedCount := totalEntries / 2
+		if routing.fixedKey != "" {
+			expectedCount = totalEntries
+		}
+		require.Len(t, points, expectedCount)
 
 		for _, point := range points {
 			require.Equal(t, shardKey, point.GetShardKey().GetKeyword())
-			require.Equal(t, shardKey, point.Payload["shard"].GetStringValue())
+			if routing.fixedKey == "" {
+				require.Equal(t, shardKey, point.Payload["shard"].GetStringValue())
+			}
 
 			pointID := point.Id.GetUuid()
 			expectedVector := expectedPointsByID[pointID]
@@ -162,13 +177,22 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 }
 
 func TestMigrateFromQdrantWithShardKeys(t *testing.T) {
-	testMigrateFromQdrantWithShardKeys(t, "source_collection", "target_collection", 1, "")
+	testMigrateFromQdrantWithShardKeys(t, "source_collection", "target_collection", 1, targetShardRouting{})
 }
 
 func TestMigrateFromQdrantWithShardKeysParallel(t *testing.T) {
-	testMigrateFromQdrantWithShardKeys(t, "source_collection_parallel", "target_collection_parallel", 4, "")
+	testMigrateFromQdrantWithShardKeys(t, "source_collection_parallel", "target_collection_parallel", 4, targetShardRouting{})
 }
 
 func TestMigrateFromQdrantWithShardKeyField(t *testing.T) {
-	testMigrateFromQdrantWithShardKeys(t, "source_collection_flat", "target_collection_custom", 4, "shard")
+	testMigrateFromQdrantWithShardKeys(t, "source_collection_flat", "target_collection_custom", 4, targetShardRouting{
+		flag: "--target.shard-key-field=shard",
+	})
+}
+
+func TestMigrateFromQdrantWithTargetShardKey(t *testing.T) {
+	testMigrateFromQdrantWithShardKeys(t, "source_collection_fixed", "target_collection_fixed", 4, targetShardRouting{
+		flag:     "--target.shard-key=target_shard",
+		fixedKey: "target_shard",
+	})
 }

--- a/integration_tests/migrate_from_qdrant_custom_sharding_test.go
+++ b/integration_tests/migrate_from_qdrant_custom_sharding_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targetCollectionName string, numWorkers int) {
+func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targetCollectionName string, numWorkers int, shardKeyField string) {
 	ctx := context.Background()
 
 	sourceContainer := qdrantContainer(ctx, t, qdrantAPIKey)
@@ -56,23 +56,28 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 	require.NoError(t, err)
 	defer targetClient.Close()
 
-	err = sourceClient.CreateCollection(ctx, &qdrant.CreateCollection{
+	createSource := &qdrant.CreateCollection{
 		CollectionName: sourceCollectionName,
 		VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
 			Size:     dimension,
 			Distance: qdrant.Distance_Dot,
 		}),
-		ShardingMethod: qdrant.ShardingMethod_Custom.Enum(),
-	})
+	}
+	if shardKeyField == "" {
+		createSource.ShardingMethod = qdrant.ShardingMethod_Custom.Enum()
+	}
+	err = sourceClient.CreateCollection(ctx, createSource)
 	require.NoError(t, err)
 
 	shardKeys := []string{"shard_a", "shard_b"}
 
-	for _, shardKey := range shardKeys {
-		err = sourceClient.CreateShardKey(ctx, sourceCollectionName, &qdrant.CreateShardKey{
-			ShardKey: qdrant.NewShardKey(shardKey),
-		})
-		require.NoError(t, err)
+	if shardKeyField == "" {
+		for _, shardKey := range shardKeys {
+			err = sourceClient.CreateShardKey(ctx, sourceCollectionName, &qdrant.CreateShardKey{
+				ShardKey: qdrant.NewShardKey(shardKey),
+			})
+			require.NoError(t, err)
+		}
 	}
 
 	expectedPointsByID := make(map[string][]float32)
@@ -93,14 +98,17 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 			})
 		}
 
-		_, err = sourceClient.Upsert(ctx, &qdrant.UpsertPoints{
+		upsert := &qdrant.UpsertPoints{
 			CollectionName: sourceCollectionName,
 			Points:         points,
-			ShardKeySelector: &qdrant.ShardKeySelector{
+			Wait:           qdrant.PtrOf(true),
+		}
+		if shardKeyField == "" {
+			upsert.ShardKeySelector = &qdrant.ShardKeySelector{
 				ShardKeys: []*qdrant.ShardKey{qdrant.NewShardKey(shardKey)},
-			},
-			Wait: qdrant.PtrOf(true),
-		})
+			}
+		}
+		_, err = sourceClient.Upsert(ctx, upsert)
 		require.NoError(t, err)
 	}
 
@@ -114,6 +122,9 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 		fmt.Sprintf("--target.collection=%s", targetCollectionName),
 		fmt.Sprintf("--migration.num-workers=%d", numWorkers),
 		"--migration.create-collection=true",
+	}
+	if shardKeyField != "" {
+		args = append(args, fmt.Sprintf("--target.shard-key-field=%s", shardKeyField))
 	}
 
 	runMigrationBinary(t, args)
@@ -151,9 +162,13 @@ func testMigrateFromQdrantWithShardKeys(t *testing.T, sourceCollectionName, targ
 }
 
 func TestMigrateFromQdrantWithShardKeys(t *testing.T) {
-	testMigrateFromQdrantWithShardKeys(t, "source_collection", "target_collection", 1)
+	testMigrateFromQdrantWithShardKeys(t, "source_collection", "target_collection", 1, "")
 }
 
 func TestMigrateFromQdrantWithShardKeysParallel(t *testing.T) {
-	testMigrateFromQdrantWithShardKeys(t, "source_collection_parallel", "target_collection_parallel", 4)
+	testMigrateFromQdrantWithShardKeys(t, "source_collection_parallel", "target_collection_parallel", 4, "")
+}
+
+func TestMigrateFromQdrantWithShardKeyField(t *testing.T) {
+	testMigrateFromQdrantWithShardKeys(t, "source_collection_flat", "target_collection_custom", 4, "shard")
 }


### PR DESCRIPTION
PM-572

Users can now use `--target.shard-key` or `--target.shard-key-field` specify shard keys to route points to.

## New doc

<img width="1095" height="522" alt="Screenshot 2026-07-15 at 11 55 33 PM" src="https://github.com/user-attachments/assets/773942e5-0f3b-4c1c-867c-ab8419ec0dcd" />
